### PR TITLE
Add rotation sync

### DIFF
--- a/Blaster/Header/Independent/Math/Transform.hpp
+++ b/Blaster/Header/Independent/Math/Transform.hpp
@@ -233,11 +233,15 @@ namespace Blaster::Independent::Math
             using Clock = std::chrono::steady_clock;
 
             const bool positionChanged = (localPosition != lastSyncedPosition);
+            const bool rotationChanged = (localRotation != lastSyncedRotation);
+            const bool scaleChanged = (localScale != lastSyncedScale);
 
-            if (positionChanged)
+            if (positionChanged || rotationChanged || scaleChanged)
                 pendingSync = true;
-            
+
             lastSyncedPosition = localPosition;
+            lastSyncedRotation = localRotation;
+            lastSyncedScale = localScale;
 
             if (!pendingSync)
                 return;
@@ -327,6 +331,8 @@ namespace Blaster::Independent::Math
         Vector<float, 3> localScale = { 1.0f, 1.0f, 1.0f };
 
         Vector<float, 3> lastSyncedPosition = localPosition;
+        Vector<float, 3> lastSyncedRotation = localRotation;
+        Vector<float, 3> lastSyncedScale = localScale;
 
         bool pendingSync = false;
         std::chrono::steady_clock::time_point lastSentTime = std::chrono::steady_clock::now();

--- a/Blaster/Header/Server/Entity/Entities/EntityPlayer.hpp
+++ b/Blaster/Header/Server/Entity/Entities/EntityPlayer.hpp
@@ -115,13 +115,16 @@ namespace Blaster::Server::Entity::Entities
 
             Vector<float, 2> mouseDelta = InputManager::GetInstance().GetMouseDelta();
 
-            const auto transform = camera->GetGameObject()->GetTransform();
-            Vector<float, 3> rotation = transform->GetLocalRotation();
+            const auto cameraTransform = camera->GetGameObject()->GetTransform();
+            const auto playerTransform = GetGameObject()->GetTransform();
+
+            Vector<float, 3> rotation = playerTransform->GetLocalRotation();
 
             rotation.y() -= mouseDelta.x() * MouseSensitivity;
             rotation.x() += mouseDelta.y() * MouseSensitivity;
 
-            transform->SetLocalRotation(rotation);
+            playerTransform->SetLocalRotation({ 0.0f, rotation.y(), 0.0f });
+            cameraTransform->SetLocalRotation({ rotation.x(), 0.0f, 0.0f });
         }
 
         void UpdateMovement()


### PR DESCRIPTION
## Summary
- rotate player object based on camera yaw input
- mark rotation changes for synchronization

## Testing
- `cmake -S . -B build && cmake --build build -j$(nproc)` *(fails: failed to clone glfw)*

------
https://chatgpt.com/codex/tasks/task_e_68685783d838832788ec1069f1b9716a